### PR TITLE
some fixes + mongo integrated-- working state

### DIFF
--- a/gulpfile.js/generateFiles.js
+++ b/gulpfile.js/generateFiles.js
@@ -1,8 +1,7 @@
-const { exec } = require('child_process');
 const tjs = require('ts-json-schema-generator');
 const { error, info } = require('./logs');
 const fs = require('fs');
-const { dsx } = require('ccxt');
+const path = require('path')
 
 function generateFiles(cb) {
 
@@ -12,10 +11,13 @@ function generateFiles(cb) {
         type: "*",
     };
 
-    const outputPath = "./dist/config/config.schema.json";
+    const outputPath = process.cwd() +  "/dist/config/config.schema.json";
+    const outputDir = path.dirname(outputPath)
+  
     const schema = tjs.createGenerator(config).createSchema(config.type)
     const schemaString = JSON.stringify(schema, null, 2);
-
+  
+    fs.mkdirSync(outputDir)
     fs.writeFile(outputPath, schemaString, { flag: 'wx' }, (err) => {
         if (err) error(err);
     });

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@types/mongodb": "^3.5.25",
     "ajv": "^6.12.2",
     "ansi-gray": "^0.1.1",
     "array-includes-with-glob": "^2.12.36",
@@ -27,6 +28,7 @@
     "fancy-log": "^1.3.3",
     "find": "^0.3.0",
     "lodash": "^4.17.15",
+    "mongodb": "^3.5.9",
     "ncp": "^2.0.0",
     "rimraf": "^3.0.2",
     "sqlite3": "^4.2.0",

--- a/src/boot.ts
+++ b/src/boot.ts
@@ -1,9 +1,9 @@
 import ccxt from "ccxt";
 import fs from "fs";
 import Ajv from "ajv";
-import { createConnection, getConnectionOptions } from 'typeorm';
 import log from 'fancy-log'
 import program from 'commander'
+import { MongoClient } from "mongodb"
 
 import getConfig from "./lib/getConfig";
 import { bail } from "./utils/index";
@@ -78,10 +78,19 @@ const connectExchange = async () => {
 
 const connectStore = async () => {
   try {
+    const url = "mongodb://localhost:27017"
+    const dbname = "algotia"
+    const options = {
+      useUnifiedTopology: true
+    }
 
-    const store = {}
-    return store;
+    const client = new MongoClient(url, options)
 
+    await client.connect() 
+
+    const db = client.db(dbname)
+    console.log(`Connected to ${db.databaseName} database`)
+    await client.close()
   } catch (err) {
     log.error("Error connecting to database: ", err);
   }

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -20,20 +20,23 @@ export default (bootData) => {
       .option('-P, --period <period>', 'Timeframe to retrieve records for', '1m')
       .option('-u, --until <until>', 'Unix timestamp (ms) of time to retrieve records to', pDate, exchange.milliseconds())
       .option('-l, --limit <limit>', 'Number of records to retrieve at one time', pInt, 10)
+      .option('-n, --collection-name <collectionName>', 'name for database refrence', undefined)
       .action(async (options) => {
           const {
             since,
             pair,
             period,
             until,
-            limit
+            limit,
+            collectionName,
           }:
           {
             since: number,
             pair: string,
             period: string,
             until: number,
-            limit: number
+            limit: number,
+            collectionName: string
           }= options
 
           const opts = {
@@ -41,7 +44,8 @@ export default (bootData) => {
             pair,
             period,
             until,
-            recordLimit: limit
+            recordLimit: limit,
+            name: collectionName,
           }
           
           await backfill(exchange, opts)


### PR DESCRIPTION
Integrated mongo and added a `name` option to the `backfill` command in the CLI. The string passed for this option will be used for the `name` property on the document that gets saved from the backfill command, otherwise one will be generated for them. In the `sim` command (or whatever we end up calling it), we can have the user either pass the name of the  document they want to test their strategy against, or we can list out the names of saved documents using [inquirer](https://www.npmjs.com/package/inquirer) and have the user select which document that way. 